### PR TITLE
yield update/created objects (optional)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-bulk-update-or-create
-version = 0.1.2
+version = 0.1.3
 description =  bulk_update_or_create for Django model managers
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
added `yield_objects` keyword arg to allow caller to receive resulting objects:

* created ones are a result from `.save()`
* updated ones were `SELECT`ed and updated in-place before bulk_update