### PR TITLE
Support for multiple match_field

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,6 @@ ToDo
 * [ ]  Docs!
 * [ ]  Add option to use `bulk_create` for creates: assert model is not multi-table, if enabled
 * [ ]  Fix the collation mess: the keyword arg `case_insensitive_match` should be dropped and collation detected in runtime
-* [ ]  Add support for multiple `match_field` - probably will need to use `WHERE (K1=X and K2=Y) or (K1=.. and K2=..)` instead of `IN` for those, as that SQL standard doesn't seem widely adopted yet
+* [x]  Add support for multiple `match_field` - probably will need to use `WHERE (K1=X and K2=Y) or (K1=.. and K2
+=..)` instead of `IN` for those, as that SQL standard doesn't seem widely adopted yet
 * [ ]  Link to `UPSERT` alternative package once done!

--- a/tests/tests/migrations/0001_initial.py
+++ b/tests/tests/migrations/0001_initial.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('uuid', models.IntegerField(unique=True)),
+                ('value', models.IntegerField(default=0)),
                 ('data', models.CharField(blank=True, max_length=200, null=True)),
             ],
         ),

--- a/tests/tests/models.py
+++ b/tests/tests/models.py
@@ -6,7 +6,8 @@ class RandomData(models.Model):
     objects = BulkUpdateOrCreateQuerySet.as_manager()
 
     uuid = models.IntegerField(unique=True)
+    value = models.IntegerField(default=0)
     data = models.CharField(max_length=200, null=True, blank=True)
 
     def __str__(self):
-        return f'{self.uuid} - {self.data}'
+        return f'{self.uuid} - {self.data} - {self.value}'


### PR DESCRIPTION
* added support for multiple `match_field`
* keys of `obj_map` are now composite; made as tuple of values got by `match_field` keys
* filter for existing objects is made from OR-ed sequence of `Q()` objects  
* added tests
* solving #5 