### PR TITLE
allow empty objs for bulk_update_or_create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode

--- a/bulk_update_or_create/query.py
+++ b/bulk_update_or_create/query.py
@@ -71,13 +71,16 @@ class BulkUpdateOrCreateMixin:
         case_insensitive_match=False,
         yield_objects=False,
     ):
-        if not objs:
-            raise ValueError('no objects to update_or_create...')
+        if batch_size is not None and batch_size < 0:
+            raise ValueError('Batch size must be a positive integer.')
         if not update_fields:
             raise ValueError('update_fields cannot be empty')
 
         # generators not supported (for now?), as bulk_update doesn't either
         objs = list(objs)
+        if not objs:
+            return
+
         if batch_size is None:
             batch_size = len(objs)
 


### PR DESCRIPTION
[bulk_update](https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/db/models/query.py#L543-L544) allows empty objs without raising any error.
bulk_update_or_create should too

PR for #10 